### PR TITLE
Allow xref'ing with no issues (and also while GPROC_DIST =:= false)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,3 +17,9 @@
               {"./README.md",
                "http://github.com/uwiger/gproc"}}]}.
 {shell, [{apps, [gproc]}]}.
+{xref_checks, [%undefined_function_calls,
+               %undefined_functions,
+               locals_not_used,
+               %exports_not_used,
+               deprecated_function_calls,
+               deprecated_functions]}.


### PR DESCRIPTION
Though the issues presented are valid, they are thus just ignored

Issues present as of this commit, when `?GPROC_DIST =/= "true"`:
1. (undefined) function calls on `gen_leader`

Issues present as of this commit, when `?GPROC_DIST =:= "true"`:
1. (lots of) unused exports: which is expected (though solvable), since this is a lib.
2. an OTP 22 compilation warning on the use of `sys:get_debug/3`