### PR TITLE
Fix compilation warning for impossible condition (part 2)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %% -*- erlang -*-
-{erl_opts, [debug_info]}.
+{erl_opts, [debug_info]}. % use {d, 'GPROC_DIST'} if you want gen_leader behaviour "imported"
 {deps, [
         {edown, ".*", {git, "https://github.com/uwiger/edown.git", "HEAD"}},
         {gen_leader, ".*",

--- a/src/gproc_dist.erl
+++ b/src/gproc_dist.erl
@@ -22,8 +22,7 @@
 %% <p>For a detailed description, see gproc/doc/erlang07-wiger.pdf.</p>
 %% @end
 -module(gproc_dist).
--define(GPROC_DISTED, os:getenv("GPROC_DIST") =:= "true").
--if(GPROC_DISTED).
+-ifdef(GPROC_DIST).
 -behaviour(gen_leader).
 -endif.
 


### PR DESCRIPTION
If we don't want distributed `gproc` we either don't define `GPROC_DIST` (env. variable) or define it with something not-"true"

In any case `-behaviour(gen_leader).` is present in one of the compiled source code files (`gproc_dist.erl`), which can't be used, since it'll fail internally.

This Pull Request fixes that by not compiling that **unused** code when **MACRO** `GPROC_DIST` is undefined.